### PR TITLE
Add balance option to make-random-forest

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,23 +37,22 @@
 </div>
 
 
-# CL Machine-Learning
+# CL Machine-Learning<a id="sec-1" name="sec-1"></a>
 
 CL Machine-Learning is high performance and large scale statistical
 machine learning package written in Common Lisp developed at 
 [MSI](http://cl-www.msi.co.jp).
 
 This repository contains is a authorized fork of the original CLML with the following goals in mind:
-
 -   Remove dependent libraries available from the Quicklisp repository
 -   Re-factor code to support Quicklisp packaging
 -   Organize code into independent systems based on functional category
 -   Support for SBCL, CCL, LispWorks and Allegro Common Lisp
 -   Improve documentation
 
-## Author(s):
+## Author(s):<a id="sec-1-1" name="sec-1-1"></a>
 
-### Original
+### Original<a id="sec-1-1-1" name="sec-1-1-1"></a>
 
 -   Salvi Péter
 -   Naganuma Shigeta
@@ -64,17 +63,17 @@ This repository contains is a authorized fork of the original CLML with the foll
 -   Abe Seika
 -   Kuroda Hisao
 
-### Current Branch Maintainer(s)/Authors(s):
+### Current Branch Maintainer(s)/Authors(s):<a id="sec-1-1-2" name="sec-1-1-2"></a>
 
 -   Mike Maul
 
-### Contributors:
+### Contributors:<a id="sec-1-1-3" name="sec-1-1-3"></a>
 
--   gambyte
+-   Graham Dobbins
 
-## Installation
+## Installation<a id="sec-1-2" name="sec-1-2"></a>
 
-## Requirements
+## Requirements<a id="sec-1-3" name="sec-1-3"></a>
 
 -   Language: SBCL, CCL, Allegro or Lispworks
 -   Platform: Posix compatibile platforms (Windows, Linux, BSD and derivatives)
@@ -86,9 +85,9 @@ done by set with the switch
 
 Currently development is taking place mostly on SBCL. For the near future SBCL is most stable platform.    
 
-## Installation Notes
+## Installation Notes<a id="sec-1-4" name="sec-1-4"></a>
 
-### Obtaining code
+### Obtaining code<a id="sec-1-4-1" name="sec-1-4-1"></a>
 
 Code can be obtained by one of the following methods:
 -   Clone this repository with:
@@ -99,7 +98,7 @@ Or download zip archive at
 
     https://github.com/mmaul/clml/archive/master.zip
 
-### Installing
+### Installing<a id="sec-1-4-2" name="sec-1-4-2"></a>
 
 1.  For Quicklisp **\*\***
 
@@ -111,21 +110,20 @@ Or download zip archive at
     1.  Place in a location on your ASDF search path path such as `~/common-lisp`
     2.  Start LISP and enter `(asdf:load-system :clml)`
 
-## Documentation
+## Documentation<a id="sec-1-5" name="sec-1-5"></a>
 
-### User and API Documentation
+### User and API Documentation<a id="sec-1-5-1" name="sec-1-5-1"></a>
 
 -   User and API documentation may be found on line at <http://mmaul.github.io/clml/>
 
 and also in the project directories docs/clml-manual.html.
-
 -   Tutorials may be found on the clml.tutorials blog at <https://mmaul.github.io/clml.tutorials/>
 -   Usage examples can be found in the docs/sample project directory
 -   Some notes and algorithmic details and background information can be
 
 found in the project directory docs/notes files in memo, notes and docs
 
-## Sample Data
+## Sample Data<a id="sec-1-6" name="sec-1-6"></a>
 
 The sample datasets are located outside the CLML repository.
 Fortunately CLML is able to download sample datasets from remote sites
@@ -140,10 +138,9 @@ anywhere a path to a file is required the output from
 `clml.utility.data:fetch` can be provided instead.
 
 The contents of the Sample dataset repository can be found at:
-
 -   [ CLML.DATA: <http://mmaul.github.io/clml.data/> ](http://mmaul.github.io/clml.data/)
 
-## Usage
+## Usage<a id="sec-1-7" name="sec-1-7"></a>
 
 This library is organized as a hierarchical tree of systems.
 -   clml
@@ -236,6 +233,7 @@ This library requires that default reader float for mat is set to double-float. 
 be done before loading the systems.
 
     (setf *read-default-float-format* 'double-float)
+
 -   Example below is using CLML.EXTRAS
 
 Here is a quick demonstration:
@@ -294,7 +292,7 @@ Here is a quick demonstration:
                       No->((Versicolor . 47))
            No->((Setosa . 50))
 
-## Tests
+## Tests<a id="sec-1-8" name="sec-1-8"></a>
 
 CLML uses the
 [[<https://github.com/OdonataResearchLLC/lisp-unit][lispunit>] testing
@@ -326,7 +324,7 @@ for convience.
 
     (run-tests *clustering-tests*)
 
-## Building Documentation
+## Building Documentation<a id="sec-1-9" name="sec-1-9"></a>
 
 CLML uses the a modified version of the CLOD package for it's
 dcumentation system. Specific details of using clod can be found
@@ -368,7 +366,7 @@ The CMLM manual and API documentation can be exported to the desired
 format by opening the docs/clml-manual.org and using the org-mode
 export `C-c C-e` cord.
 
-## Related Repositories
+## Related Repositories<a id="sec-1-10" name="sec-1-10"></a>
 
 -   clml.extras - <https://github.com/mmaul/clml.extras> Extended features for clml
     -   cl-plplot integration
@@ -377,7 +375,7 @@ export `C-c C-e` cord.
     -   eazy-gnuplot integration
 -   clml.tutorials - <https://github.com/mmaul/clml.tutorials> Tutorials for CLML
 
-## Contributing
+## Contributing<a id="sec-1-11" name="sec-1-11"></a>
 
 All contributions are welcome. If the contribution is to resolve and
 problem with CLML, please open an issue in the github repository 

--- a/README.org
+++ b/README.org
@@ -26,7 +26,7 @@ This repository contains is a authorized fork of the original CLML with the foll
 *** Current Branch Maintainer(s)/Authors(s):    
   +  Mike Maul
 *** Contributors:
-  +  gambyte
+  +  Graham Dobbins
 
 ** [#B] Installation
 #+INCLUDE: "./docs/INSTALL.org" :minlevel 2

--- a/test/src/test-random-forest.lisp
+++ b/test/src/test-random-forest.lisp
@@ -25,7 +25,7 @@
         
         (assert-true (string= "Versicolor" (predict-forest query syobu forest)))
         
-        (setf forest (make-random-forest bc-train "Class"))
+        (setf forest (make-random-forest bc-train "Class" :balance t))
         
         (assert-eql 4 (length (forest-validation bc-test "Class" forest)))
 


### PR DESCRIPTION
The balance option allows for equal sampling among the outcome of the
objective variable. This is really only useful when one outcome is
over-represented in the data. When enabled this option should improve
the true-positive and false-positive rates at the expense of losing some
information from the undersampled outcome and increasing bias in the
oversampled outcome.