### PR TITLE
Fixes for Allegro CL

### DIFF
--- a/statistics/src/distribution.lisp
+++ b/statistics/src/distribution.lisp
@@ -298,10 +298,10 @@
 |#
 (defmethod update-distribution ((distribution normal-distribution))
   (with-slots (std variance mode) distribution
-    #- (or ccl sbcl)
+    #- (or ccl sbcl allegro)
     (assert (realp (slot-value distribution 'average))
       "AVERAGE should be a real number.")
-    #- (or ccl sbcl)
+    #- (or ccl sbcl allegro)
     (assert (and (realp std) (> std 0)) (std)
       "STD should be a positive real number.")
     (setf (slot-value distribution 'mean) (slot-value distribution 'average))

--- a/statistics/src/rand/rand.lisp
+++ b/statistics/src/rand/rand.lisp
@@ -1822,7 +1822,7 @@
 
 
 
-#- (or ccl sbcl)
+#- (or ccl sbcl allegro)
   (let ((u-mbit (random most-positive-fixnum))
         (sign -1d0)
         (ux 0d0))

--- a/utility/src/package.lisp
+++ b/utility/src/package.lisp
@@ -9,14 +9,14 @@
            #:write-csv-stream
            #:read-csv-file-and-sort
        #:parse-csv-string))
-
+;#+allegro
+;(:use :excl)
  (defpackage :clml.utility.priority-que
 
-   (:use :cl :iterate)
+   (:use :cl )
+   (:import-from :iterate :iter)
    (:import-from :alexandria #:define-constant)
-
-   #+allegro
-   (:use :excl)
+   
   (:export #:make-prique
            #:prique-empty-p
            #:prique-box-item


### PR DESCRIPTION
Fixes for compiling with Allegro CL
statistics/src/rand/rand.lisp Line 1825,  was not defined properly change the compile option from #-(or ccl sbcl) to #-(or ccl sbcl allegro). 
 
statistics/src/distribution.lisp:  Line 301, Line 304:Error: Attempt to take the cdr of “AVERAGE should be a real number” which is not list
 
utility/src/package:Error: Using package ‘ITERATE’ results in name conflicts for these symbols: WHILE UNTIL [condition type: PACKAGE-ERROR]
 