### PR TITLE
Alter e-scores defgeneric to work with SBCL

### DIFF
--- a/time-series/src/ts-anomaly-detection.lisp
+++ b/time-series/src/ts-anomaly-detection.lisp
@@ -107,7 +107,7 @@
     (values (make-instance 'snn :names names :snn-k k :sigma-i sigma-i :graphs graphs)
             wmat)))
 
-(defgeneric e-scores (t r)
+(defgeneric e-scores (target reference)
   (:documentation "- return: alist (key:name-of-parameter, value:E-score)
 - arguments:
   - target-snn    : <snn>, target SNN


### PR DESCRIPTION
SBCL will signal an error when T is used as a lambda list variable per 3.4.2. Change T to TARGET in E-SCORES definition to avoid this problem.