### PR TITLE
Explicitly depend on Drakma

### DIFF
--- a/data/r-datasets/clml.data.r-datasets.asd
+++ b/data/r-datasets/clml.data.r-datasets.asd
@@ -11,6 +11,7 @@
                 :serial t
                 :depends-on (
                              :cl-ppcre
+                             :drakma
                              :clml.hjs
                              :clml.utility
                              :clml.data.r-datasets-package


### PR DESCRIPTION
Ensure that drakma is loaded when package.lisp attempts to use it.