### PR TITLE
Improve Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - PATH=$HOME/.roswell/bin:$PATH
     - ROSWELL_INSTALL_DIR=$HOME/.roswell
   matrix:
-#    - LISP="sbcl-bin  --dynamic-space-size 2560"
+    - LISP=sbcl-bin
     - LISP=ccl-bin
 #    allow_failures:
 #      - LISP=ccl-bin
@@ -40,6 +40,4 @@ cache:
     - $HOME/.config/common-lisp
 
 script:
-  - ros -s prove -e '(ql:quickload :clml.test)(in-package :clml.test)
-         (unless (run-all-tests)
-         (uiop:quit 1))'
+ros dynamic-space-size=2560 -e '(ql:quickload :clml.test)(in-package :clml.test)

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,8 @@ cache:
     - $HOME/.config/common-lisp
 
 script:
-ros dynamic-space-size=2560 -e '(ql:quickload :clml.test)(in-package :clml.test)
+  - ros dynamic-space-size=2560 -e '(ql:quickload :clml.test)(in-package :clml.test)
+         (let ((results (run-all-tests)))
+           (when (or (lisp-unit:failed-tests results)
+                     (lisp-unit:error-tests  results))
+             (uiop:quit 1)))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ cache:
 script:
   - ros dynamic-space-size=2560 -e '(ql:quickload :clml.test)(in-package :clml.test)
          (let ((results (run-all-tests)))
+           (print-failures results)
+           (print-errors results)
            (when (or (lisp-unit:failed-tests results)
                      (lisp-unit:error-tests  results))
              (uiop:quit 1)))'

--- a/test/src/test-k-means.lisp
+++ b/test/src/test-k-means.lisp
@@ -4,7 +4,7 @@
 (define-test test-sample-k-means
     (let (dataset centroids result)
       (assert
-       (setf dataset (read-data-from-file (clml.utility.data:fetch "https://mmaul.github.io/clml.data/sample/pos.sexp") :external-format #+allegro :932 #+sbcl :sjis #+ccl :Windows-31 #+lispworks :sjisj)))
+       (setf dataset (read-data-from-file (clml.utility.data:fetch "https://mmaul.github.io/clml.data/sample/pos.sexp") :external-format #+allegro :932 #+sbcl :sjis #+ccl :Windows-31j #+lispworks :sjisj)))
       (assert
        (setf dataset
          (pick-and-specialize-data dataset :range '(2 3) :data-types '(:numeric :numeric))))
@@ -20,4 +20,3 @@
           do (assert-eql (c-size cluster) (length pts))
              (loop for pt across pts
                  do (assert-true (find pt (mapcar #'p-pos (c-points cluster)) :test #'point-equal))))))
-

--- a/test/src/test-k-nn.lisp
+++ b/test/src/test-k-nn.lisp
@@ -48,11 +48,11 @@
         (assert-points-equal
          (map 'vector (lambda (pts) (map 'clml.hjs.meta:dvec
                                       (lambda (val m)
-                                        #+sbcl ; sbcl bug
+                                        #+(or sbcl ccl)
                                         (if (zerop m)
                                             0d0
                                             (/ val m))
-                                        #-sbcl
+                                        #-(or sbcl ccl)
                                         (handler-case (/ val m)
                                           (division-by-zero (c) (declare (ignore c)) 0d0)))
                                       (subseq pts 1)
@@ -78,5 +78,3 @@
                         "116" "80" "128" "188" "97" "167" "197" "196" "196" "196")
                       (map 'list (lambda (vec) (svref vec 0)) (dataset-points result))
                       :test #'string=)))))
-
-

--- a/test/src/test-ts-burst-detection.lisp
+++ b/test/src/test-ts-burst-detection.lisp
@@ -35,7 +35,7 @@
          (:INDEX 2 :START 450.0 :END 570.0) (:INDEX 3 :START 565.0 :END 570.0)
          (:INDEX 1 :START 710.0 :END 780.0)))
       (assert-equality
-       #'equal
+       #'string-equal
        (let ((str (make-array 0 :element-type 'character
                               :adjustable t :fill-pointer t)))
          (with-output-to-string (s str)


### PR DESCRIPTION
The is fixes for a couple of test related issues.

1) Tests were only being run on CCL, event though SBCL, CCL, LispWorks and Allegro are all listed as supported.
    * I added SBCL, since it was passing tests
    * The others were erroring, so I didn't add them
2) `(run-all-tests)` returns an object containing test results, so test failure's weren't being reported to travis
3) There was no information being printed on failing and erroring tests
4) There are failing/erroring tests when running on ccl.  I fixed some of them, but didn't figure out the solution for all of them.  The fixed problems were:
    * test-ts-burst-detection was case sensative on the float output
    * test-sample-k-means was using the wrong name for shift jis
    * test-k-nn didn't recieve the expected error on 0/0