### PR TITLE
Add support for alternate csv delimiters

### DIFF
--- a/hjs/src/read-data.lisp
+++ b/hjs/src/read-data.lisp
@@ -489,6 +489,7 @@
                                      (external-format :default external-format-p)
                                      csv-type-spec
                                      (csv-header-p t)
+                                     (csv-delimiter #\,)
                                      (missing-value-check t)
                                      missing-values-list)
   "Reads CSV data from file. The normal convention is first line is column name.
@@ -514,7 +515,7 @@ However if CSV-HEADER-P is a list of strings then CSV-HEADER-P specifies the col
         :missing-values-list missing-values-list)))
     (:csv
      (multiple-value-bind (data header)
-         (clml.utility.csv:read-csv-file filename :header csv-header-p :type-spec csv-type-spec
+         (clml.utility.csv:read-csv-file filename :header csv-header-p :type-spec csv-type-spec :delimiter csv-delimiter
                             :external-format (if external-format-p external-format
                                                  #+allegro :932
                                                  #+ccl :Windows-31j
@@ -531,12 +532,13 @@ However if CSV-HEADER-P is a list of strings then CSV-HEADER-P specifies the col
 (defun read-data-from-stream (stream &key
                                      csv-type-spec
                                      (csv-header-p t)
+                                     (csv-delimiter #\,)
                                      (missing-value-check t)
                                      missing-values-list)
   "Reads CSV data from a stream. The normal convention is first line is column name.
 However if CSV-HEADER-P is a list of strings then CSV-HEADER-P specifies the column names"
   (multiple-value-bind (data header)
-         (clml.utility.csv:read-csv-stream stream :header csv-header-p :type-spec csv-type-spec)
+         (clml.utility.csv:read-csv-stream stream :header csv-header-p :type-spec csv-type-spec :delimiter csv-delimiter)
        (make-unspecialized-dataset (coerce header 'list) data
 
                                      :missing-value-check missing-value-check
@@ -1478,11 +1480,11 @@ However if CSV-HEADER-P is a list of strings then CSV-HEADER-P specifies the col
           finally (return (coerce result 'vector)
                           )))))
 
-(defmethod write-dataset ((dataset clml.hjs.read-data::dataset) filename &key (external-format clml.utility.csv::*csv-default-external-format*))
+(defmethod write-dataset ((dataset clml.hjs.read-data::dataset) filename &key (csv-delimiter #\,) (external-format clml.utility.csv::*csv-default-external-format*))
   " Write dataset to csv formated file"
   (with-open-file (f filename :direction :output
                      :if-does-not-exist :create
                      :if-exists :supersede
                      :external-format external-format)
-    (clml.utility.csv:write-csv-stream f (vector (map '(vector string) #'dimension-name (dataset-dimensions dataset))))
-    (clml.utility.csv:write-csv-stream f (dataset-points dataset))))
+    (clml.utility.csv:write-csv-stream f (vector (map '(vector string) #'dimension-name (dataset-dimensions dataset))) :delimiter csv-delimiter)
+    (clml.utility.csv:write-csv-stream f (dataset-points dataset) :delimiter csv-delimiter)))


### PR DESCRIPTION
Reading and writing .csv files can now be customized to use any
character as a delimiter instead of being locked to #\,

I have some numeric data containing commas, so I was unable to use clml.hjs.read-data:read-data-from-file to read it. I have added a keyword :csv-delimiter to the relevant read/write funtions in clml.hjs.read-data and the keyword :delimiter to the relevant funtions in clml.utility.csv, with all of them defaulting to the comma to prevent existing code from being affected.