### PR TITLE
Fixed bug on ccl with incorrect typing breaking m^-1 function.

### DIFF
--- a/hjs/src/matrix.lisp
+++ b/hjs/src/matrix.lisp
@@ -481,10 +481,12 @@
          (m (array-dimension A 1))
          (n (array-dimension A 0))
          (lda (max 1 m))
-         (ipiv (make-array (min m n) :element-type
+         (ipiv (let ((%ipiv (make-array (min m n) :element-type
                            #+ (or ccl sbcl lispworks) '(signed-byte 32)
                            #+allegro 'fixnum
-                           ))
+                           )))
+				 #+ccl (coerce %ipiv 'CCL::SIMPLE-FIXNUM-VECTOR)
+				 #-ccl %ipiv))
          (lwork (* m n 2))
          (work (make-array lwork :element-type 'double-float))
          (info 0))


### PR DESCRIPTION
On ccl, the original m^-1 function (and anything that depends on it, such as logistic regression, fails due to bad typing).
This PR is a proposed solution for this problem (tested on ccl to fix this issue).