### PR TITLE
Move clml.data.r-datasets-package to its own .ASD file for Quicklisp

### DIFF
--- a/data/r-datasets/clml.data.r-datasets-package.asd
+++ b/data/r-datasets/clml.data.r-datasets-package.asd
@@ -1,0 +1,7 @@
+(asdf:defsystem :clml.data.r-datasets-package
+                :pathname "src/"
+                :serial t
+                :components (
+                             (:file "package"))
+                )
+

--- a/data/r-datasets/clml.data.r-datasets.asd
+++ b/data/r-datasets/clml.data.r-datasets.asd
@@ -1,11 +1,3 @@
-(asdf:defsystem :clml.data.r-datasets-package
-                :pathname "src/"
-                :serial t
-                :components (
-                             (:file "package"))
-                )
-
-
 (asdf:defsystem :clml.data.r-datasets
                 :pathname "src/"
                 :serial t


### PR DESCRIPTION
Move clml.data.r-datasets-package to its own .ASD file. Quicklisp was not finding this system otherwise.

I am not sure why that is a problem. The system is referenced as a dependency by data/r-datasets/clml.data.r-datasets.asd which seems to have already defined this system in that same file. However I chose to make this simple change rather than deep dive into Quicklisp and ASDF.